### PR TITLE
extraction nom marqueur

### DIFF
--- a/R/grp_lasso.R
+++ b/R/grp_lasso.R
@@ -220,65 +220,27 @@ summary.stabsel <- function(st, cutoff = 0.85, map, mrk2lg){
     #   map_dfc(~c(.[1],
     #          str_split("\\.", .[2]) %>%
     #            map_dfr(~c(paste(.[-length(.)], collapse = "."), .[length(.)]))))
-
-    if (length(select) != 0){
-
+  if (length(select) != 0){
+    
     Tr  <- select %>% names() %>%
-         str_split('_',2, simplify = FALSE)
+      str_split('_',2, simplify = FALSE)
     trait <- Tr %>%  map_chr(~ if (length(.) > 1 ){ .[1]
-      } else {"all"})
-
-    Mr <- Tr %>%
-      map_chr(~.[length(.)]) %>%
-      str_split( .,'\\.')
-
-    marker <- Mr %>%
-      map_chr(~.[1])
-
-    allele <- Mr %>%
-      map_chr(~.[2])
-
+    } else {"all"})
+    Tr <- unlist(Tr)
+    extract <- regmatches(Tr, regexec("([a-zA-Z0-9._-]*)\\.([a-z]{1,2})", Tr, perl=TRUE))
+    marker <- unlist(lapply(extract, `[`, 2))
+    allele <- unlist(lapply(extract, `[`, 3))
+    extract2 <- regmatches(mrk2lg[marker], 
+                                regexec("C([0-1]{1}[0-9]{1})fw2K",
+                                        mrk2lg[marker], perl=TRUE))
+    linkage_group <- unlist(lapply(extract2, `[`, 2))
     mp <- suppressWarnings( as.numeric(map[,2]))
     names(mp) <- map$V1
-    cbind.data.frame(trait, marker, allele, linkage_group = mrk2lg[marker], position =mp[marker] , probability = st$max[select], idx = 0)
-    } else {
-      cbind.data.frame(trait = 0, marker = 0, allele = 0, linkage_group = 0, position =0 , probability = 0, idx = 0)
-
+    cbind.data.frame(trait, marker, allele, linkage_group, position=mp[marker] , probability = st$max[select], idx = 0)
+  } else {
+    cbind.data.frame(trait = 0, marker = 0, allele = 0, linkage_group = 0, position =0 , probability = 0, idx = 0)
+    
+  }
 }
-}
-
-# summary.stabsel(st, map = map, mrk2lg)
-
-#' Give the result for a group lasso
-#'
-#' @param  X a matrix with the value of different allele for different Marker
-#' @param  Y a vector or a matrix with the values of different Trait
-#' @param  type_group a character indicating the way of creating the group :
-#' "both" means that the variable are selected for all a Marker for all the Trait.
-#' "marker" means that the variable are selected for a Marker but for one Trait.
-#' "trait" means that a variable are selected for all the Trait but not for all the marker but just for one allele
-#' @param  a the parameters that indicate how much the coefficients will be fused
-#' @param  lambda if the user wants to use it owns values of lambdas
-#' @return The coefficients of the fused lasso ANCOVA for the different value of lambda
-#' @examples
-#' B <- c(1, -1, 1.5, 1.5, rep(0, 6), 2, 0, 2, 0)
-#'group <- c(rep('M1', 10), rep('M2', 10))
-#'regressors <- matrix(rnorm(6*20), ncol = 6)
-#'X  <- model.matrix(~group + group:regressors - 1)
-#'y <- X%*%B + rnorm(20)
-#'y <- scale(y)
-#'mod <- fl2(y, regressors, group)
-#'colors <- c(rep("grey",2), rep('green',2),rep('black', 6), rep(c("orange","blue"), 2), 'darkgreen', rep('yellow',3), rep('purple',2))
-#'matplot(mod$lambda ,t(mod$beta),type='l',col=colors)
-#' @export
-grpLassoQTL <- function(X, Y, map,
-                        PFER=1, B=500, cutoff=0.85,  nb.cores, sep ="\\.", mrk2lg, type_group="both", verbose = FALSE){
-  Y   <- as.matrix(Y)
-  if (is.null(colnames(Y))) colnames(Y) <- paste0('Y', 1:ncol(Y))
-  st  <- gglasso_st_tot(X, Y, group = NULL, sep = sep, nb.cores = nb.cores, B = B, PFER = PFER, type_group = type_group, verbose = verbose)
-  summary(st, cutoff = cutoff, map, mrk2lg)
-}
-
-# md <-grp_lasso(X, Y)
 
 


### PR DESCRIPTION
Certains noms de marqueurs sont tordus, quand le marqueur sélectionné était "VMC4.2" par exemple, ta fonction renvoyait le marqueur "VMC4" et l'allèle 2 ce qui posait des problèmes ensuite. J'ai réglé ça et j'ai extrait directement le numéro du groupe de liaison au lieu de la chaîne de caractère contenue dans le fichier map.